### PR TITLE
feat(auth): Discord OAuth2 for overlay + session-based API guards

### DIFF
--- a/connect/oauth.py
+++ b/connect/oauth.py
@@ -1,0 +1,58 @@
+# connect/oauth.py
+from __future__ import annotations
+import os, secrets, string, requests
+from typing import Tuple, Dict, Any, Optional
+
+DISCORD_BASE = "https://discord.com/api"
+CLIENT_ID = os.getenv("DISCORD_CLIENT_ID", "")
+CLIENT_SECRET = os.getenv("DISCORD_CLIENT_SECRET", "")
+REDIRECT_URI = os.getenv("DISCORD_REDIRECT_URI", "http://localhost:3000/auth/callback")
+SCOPES = os.getenv("DISCORD_OAUTH_SCOPES", "identify guilds").split()
+
+TIMEOUT = 8
+
+def _rand_state(n: int = 32) -> str:
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(n))
+
+def make_authorize_url(state: str) -> str:
+    from urllib.parse import urlencode
+    q = urlencode({
+        "client_id": CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "response_type": "code",
+        "scope": " ".join(SCOPES),
+        "prompt": "consent",
+        "state": state,
+    })
+    return f"{DISCORD_BASE}/oauth2/authorize?{q}"
+
+def exchange_code_for_token(code: str) -> Dict[str, Any]:
+    data = {
+        "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET,
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": REDIRECT_URI,
+    }
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    r = requests.post(f"{DISCORD_BASE}/oauth2/token", data=data, headers=headers, timeout=TIMEOUT)
+    r.raise_for_status()
+    return r.json()  # {access_token, token_type, expires_in, scope, refresh_token}
+
+def fetch_user_me(access_token: str) -> Dict[str, Any]:
+    headers = {"Authorization": f"Bearer {access_token}"}
+    r = requests.get(f"{DISCORD_BASE}/users/@me", headers=headers, timeout=TIMEOUT)
+    r.raise_for_status()
+    return r.json()
+
+def fetch_user_guilds(access_token: str) -> list[Dict[str, Any]]:
+    headers = {"Authorization": f"Bearer {access_token}"}
+    r = requests.get(f"{DISCORD_BASE}/users/@me/guilds", headers=headers, timeout=TIMEOUT)
+    r.raise_for_status()
+    return r.json()
+
+def start_oauth_flow() -> Tuple[str, str]:
+    """Retourne (state, authorize_url)."""
+    st = _rand_state()
+    return st, make_authorize_url(st)

--- a/connect/session_auth.py
+++ b/connect/session_auth.py
@@ -1,0 +1,47 @@
+# connect/session_auth.py
+from __future__ import annotations
+from typing import Optional, Dict, Any
+from flask import session, redirect, url_for, jsonify, request
+from functools import wraps
+import os
+
+SESSION_KEY = "discord_user"
+STATE_KEY = "oauth_state"
+
+def set_user_session(user: Dict[str, Any]) -> None:
+    """Stocke l'utilisateur Discord (payload /users/@me) dans la session Flask."""
+    session[SESSION_KEY] = {
+        "id": str(user.get("id")),
+        "username": user.get("username"),
+        "global_name": user.get("global_name"),
+        "discriminator": user.get("discriminator"),
+        "avatar": user.get("avatar"),
+    }
+
+def clear_user_session() -> None:
+    session.pop(SESSION_KEY, None)
+    session.pop(STATE_KEY, None)
+
+def current_user() -> Optional[Dict[str, Any]]:
+    return session.get(SESSION_KEY)
+
+def is_logged_in() -> bool:
+    u = current_user()
+    return bool(u and u.get("id"))
+
+def login_required(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        if not is_logged_in():
+            # 401 pour que le front déclenche le bouton "Se connecter"
+            if request.path.startswith("/api/"):
+                return jsonify({"error": "auth_required"}), 401
+            return redirect(url_for("auth_login", next=request.url))
+        return fn(*args, **kwargs)
+    return wrapper
+
+def save_oauth_state(value: str) -> None:
+    session[STATE_KEY] = value
+
+def pop_oauth_state() -> Optional[str]:
+    return session.pop(STATE_KEY, None)


### PR DESCRIPTION
- add /auth/login, /auth/callback, /auth/logout routes
- add /api/me to expose logged-in Discord user
- protect state-changing endpoints with @login_required
- /api/play now uses session user (no client-provided user_id)
- enable CORS with credentials + session cookie config
- keep overlay payload + existing endpoints unchanged otherwise

BREAKING CHANGE: /api/play no longer accepts `user_id`. The client must be logged in; front-end should call GET /api/me and send credentials (cookies) with requests.

env:
- DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, DISCORD_REDIRECT_URI
- DISCORD_OAUTH_SCOPES (default: "identify guilds")
- RESTRICT_TO_GUILD_ID (optional: limit access to a specific server)
- SESSION_COOKIE_NAME, SESSION_COOKIE_SAMESITE (use None if cross-site), SESSION_COOKIE_SECURE, FLASK_SECRET_KEY

front-end notes:
- fetch(..., { credentials: "include" })
- if /api/me returns 401, redirect to /auth/login or show a “Login with Discord” button